### PR TITLE
[Fix] Improve card name search with phrase matching

### DIFF
--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -11,12 +11,25 @@ impl QueryHolder {
 			doc! {
 				"$search": {
 					"index": index,
-					"text": {
-						"query": query,
-						"path": path,
-						"fuzzy": {
-							"maxEdits": 1
-						}
+					"compound": {
+						"should": [
+							doc! {
+								"text": {
+									"query": query,
+									"path": path,
+									"fuzzy": {
+										"maxEdits": 1
+									}
+								}
+							},
+							doc! {
+								"phrase": {
+									"query": query,
+									"path": path,
+									"slop": 0
+								}
+							}
+						]
 					}
 				}
 			}


### PR DESCRIPTION
- Add phrase matching to search compound
- Prioritize phrase matches over repeated keywords

Example:
  Query: "monster reborn" Old result: "Monster Reborn Reborn" New result: "Monster Reborn"